### PR TITLE
Add initial permissions to manifest

### DIFF
--- a/CS446Project/app/src/main/AndroidManifest.xml
+++ b/CS446Project/app/src/main/AndroidManifest.xml
@@ -2,6 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.qian.cs446project">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
@KeQiaoChen @APBdev 

Simply adding permissions required me and Andrew to the manifest file only. This is not working on the emulator, but seems to be working just fine when testing on actual devices.